### PR TITLE
Output summary of AMI change

### DIFF
--- a/jenkins-update-ec2-ami.py
+++ b/jenkins-update-ec2-ami.py
@@ -185,6 +185,8 @@ def main():
     if not old_jenkins_ami_id:
         print "Could not find (current) Jenkins AMI ID -- moving on"
 
+    print "New AMI ID: %s, Old AMI ID: %s" % (packer_ami_id, old_jenkins_ami_id)
+
     update_success = update_jenkins_ami_id(packer_ami_id)
     if not update_success:
         print "Ran into an error when attempting to update the Jenkins AMI ID"


### PR DESCRIPTION
I’ve found it useful to know the AMI swap when debugging a recent issue (which actually led me to this script). We were getting something like this ...

```
07:08:11 ==> Builds finished. The artifacts of successful builds are:
07:08:11 --> amazon-ebs: AMIs were created:
07:08:11 us-east-1: ami-7e2b1205
07:08:11 
07:08:13 New ID: None, Old ID: ami-3cd135d7
07:08:17 Deleting previous Jenkins AMI ami-3cd135d7 in AWS
07:08:18 Finished: SUCCESS
```

Which probably hints that we should be checking `packer_ami_id` is valid. 🤔 